### PR TITLE
Call the handler function instead of echoing the output of the function

### DIFF
--- a/autoload/gonvim_fuzzy.vim
+++ b/autoload/gonvim_fuzzy.vim
@@ -42,7 +42,7 @@ function! gonvim_fuzzy#exec(options)
     let s:arg = a:options.arg
     if has_key(a:options, 'function')
         let s:f = function(a:options.function)
-        echo s:f(s:arg)
+        call s:f(s:arg)
     endif
 endfunction
 


### PR DESCRIPTION
When using GonvimFuzzyFiles in multi_grid branch, I was able to 'echo 0' was calling unnecessarily.
On debugging found we are trying to echo the output of handler function which is unnecessary